### PR TITLE
package.json: fetch node-github from Github over https

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "mkdirp": "~0.3.5",
     "rimraf": "~2.2.2",
-    "github": "git://github.com/guybedford/node-github.git",
+    "github": "git+https://github.com/guybedford/node-github.git",
     "tar": "~0.1.18",
     "request": "~2.27.0"
   }


### PR DESCRIPTION
Git and SSH are often blocked by many proxies.

Signed-off-by: Anurag Priyam anurag08priyam@gmail.com
