### PR TITLE
Fixed invalid promise rejection

### DIFF
--- a/github.js
+++ b/github.js
@@ -206,8 +206,7 @@ GithubLocation.configure = function(config, ui) {
         return Promise.resolve(ui.input('Enter the hostname of your GitHub Enterprise server', 'github.com'))
           .then(function(hostname) {
             if (!hostname || hostname == '') {
-              ui.log('warn', 'Invalid hostname was entered')
-              return Promise.reject()
+              return Promise.reject('Invalid hostname was entered.');
             }
             config.hostname = hostname
             return


### PR DESCRIPTION
If no message or error is given when rejecting the promise an unhandled
exception gets raised at [cli.js:407](https://github.com/jspm/jspm-cli/blob/d8c33e7cb07005684efe67cc417ba023f6f3ef74/cli.js#L407) when trying to access `err.stack`.