### PR TITLE
Set default github hostname

### DIFF
--- a/github.js
+++ b/github.js
@@ -209,6 +209,7 @@ function checkRateLimit(headers) {
 // static configuration function
 GithubLocation.configure = function(config, ui) {
   config.remote = config.remote || 'https://github.jspm.io';
+  config.hostname = config.hostname || 'github.com';
 
   return (config.name != 'github' ? Promise.resolve(ui.confirm('Are you setting up a GitHub Enterprise endpoint?', true)) : Promise.resolve())
   .then(function(enterprise) {


### PR DESCRIPTION
hostname is undefined and gives a malformed output.

`$ jspm endpoint config github`
`Would you like to set up your GitHub credentials? [yes]:
     If using two-factor authentication or to avoid using your password you can generate an access token at https://undefined/settings/applications.`