### PR TITLE
feat(netrc): add support for getting github credentials from the .netrc ...

### DIFF
--- a/github.js
+++ b/github.js
@@ -44,8 +44,9 @@ function decodeCredentials(str) {
     password: decodeURIComponent(auth[1])
   };
 }
-function readNetrc() {
-  var creds = netrc('github.com');
+function readNetrc(hostname) {
+  hostname = hostname || 'github.com';
+  var creds = netrc(hostname);
 
   if (creds) {
     return {
@@ -82,7 +83,7 @@ var GithubLocation = function(options, ui) {
     this.auth = decodeCredentials(options.auth);
   }
   else {
-    this.auth = readNetrc();
+    this.auth = readNetrc(options.hostname);
   }
 
   this.execOpt = {

--- a/github.js
+++ b/github.js
@@ -17,6 +17,8 @@ var semver = require('semver');
 
 var which = require('which');
 
+var netrc = require('node-netrc');
+
 function createRemoteStrings(auth, hostname) {
   var authString = auth ? (encodeURIComponent(auth.username) + ':' + encodeURIComponent(auth.password) + '@') : '';
   hostname = hostname || 'github.com';
@@ -41,6 +43,16 @@ function decodeCredentials(str) {
     username: decodeURIComponent(auth[0]),
     password: decodeURIComponent(auth[1])
   };
+}
+function readNetrc() {
+  var creds = netrc('github.com');
+
+  if (creds) {
+    return {
+      username: creds.login,
+      password: creds.password
+    };
+  }
 }
 
 var GithubLocation = function(options, ui) {
@@ -68,6 +80,9 @@ var GithubLocation = function(options, ui) {
 
   if (options.auth) {
     this.auth = decodeCredentials(options.auth);
+  }
+  else {
+    this.auth = readNetrc();
   }
 
   this.execOpt = {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "decompress-zip": "^0.1.0",
     "graceful-fs": "^3.0.6",
     "mkdirp": "~0.5.0",
+    "node-netrc": "0.0.1",
     "request": "~2.53.0",
     "rimraf": "~2.3.2",
     "rsvp": "^3.0.17",


### PR DESCRIPTION
...file

This changes uses the 'node-netrc' package to read github credentials from ~/.netrc. The netrc file is only used if the credentials have not been configured in ~/.jspm/config (via the jspm cli)