### PR TITLE
feat(netrc): add support for getting credentials from ~/.netrc file

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "decompress-zip": "^0.1.0",
     "graceful-fs": "^3.0.6",
     "mkdirp": "~0.5.0",
+    "netrc": "^0.1.3",
     "request": "~2.53.0",
     "rimraf": "~2.3.2",
     "rsvp": "^3.0.17",

--- a/test.js
+++ b/test.js
@@ -8,11 +8,14 @@ github = new github({
   password: ''
 });
 
-github.getVersions('angular/bower-angular', function(versions) {
-  console.log(versions);
-  github.download('angular/bower-angular', 'v1.2.12', 'e8a1df5f060bf7e6631554648e0abde150aedbe4', 'test-repo', function() {
+github.lookup('angular/bower-angular')
+  .then(function(versions) {
+    console.log(versions);
+    return github.download('angular/bower-angular', 'v1.2.12', 'e8a1df5f060bf7e6631554648e0abde150aedbe4', {}, 'test-repo');
+  })
+  .then(function() {
     console.log('done');
-  }, function(err) {
+  })
+  .catch(function(err) {
     console.log(err);
   });
-});


### PR DESCRIPTION
This adds support for getting credentials from a 'github.com' machine entry in the ~/.netrc file. Credentials configured via ```jspm registry config``` will take precedence.

Also updated some of the console messages to inform the user that they can use ~/.netc.
Uses the npm ```netrc``` package directly.