### PR TITLE
Allow Github auth via environment variable.

### DIFF
--- a/github.js
+++ b/github.js
@@ -75,7 +75,10 @@ var GithubLocation = function(options, ui) {
 
   this.versionString = options.versionString + '.1';
 
-  if (options.username && !options.auth) {
+  // Give the environment precedence over options object
+  if(process.env.JSPM_GITHUB_AUTH_TOKEN) {
+    options.auth = process.env.JSPM_GITHUB_AUTH_TOKEN;
+  } else if (options.username && !options.auth) {
     options.auth = encodeCredentials(options);
     // NB deprecate old auth eventually
     // delete options.username;


### PR DESCRIPTION
Following on from discussion on https://github.com/jspm/jspm-cli/pull/922, moved functionality here.

I've given the environment precedence over the options object since that made the most sense to me, but I'm fine with swapping the order.