### PR TITLE
Also remove peerDependencies during processPackageConfig

### DIFF
--- a/github.js
+++ b/github.js
@@ -432,7 +432,7 @@ GithubLocation.prototype = {
 
     var self = this;
 
-    if (packageConfig.dependencies && !packageConfig.registry && (!packageConfig.jspm || !packageConfig.jspm.dependencies)) {
+    if ((packageConfig.peerDependencies || packageConfig.dependencies) && !packageConfig.registry && (!packageConfig.jspm || !packageConfig.jspm.dependencies)) {
       var hasDependencies = false;
       for (var p in packageConfig.dependencies)
         hasDependencies = true;
@@ -455,11 +455,13 @@ GithubLocation.prototype = {
 
         if (noDepsMsg) {
           delete packageConfig.dependencies;
+          delete packageConfig.peerDependencies;
           this.ui.log('warn', '`' + packageName + '` dependency installs skipped as it\'s a GitHub package with no registry property set.\n' + noDepsMsg + '\n');
         }
       }
       else {
         delete packageConfig.dependencies;
+        delete packageConfig.peerDependencies;
       }
     }
 

--- a/github.js
+++ b/github.js
@@ -434,8 +434,12 @@ GithubLocation.prototype = {
 
     if ((packageConfig.peerDependencies || packageConfig.dependencies) && !packageConfig.registry && (!packageConfig.jspm || !packageConfig.jspm.dependencies)) {
       var hasDependencies = false;
-      for (var p in packageConfig.dependencies)
+
+      if (Object.keys(packageConfig.dependencies || {}).length > 0) {
         hasDependencies = true;
+      } else if (Object.keys(packageConfig.peerDependencies || {}).length > 0) {
+        hasDependencies = true;
+      }
 
       if (packageName && hasDependencies) {
         var looksLikeNpm = packageConfig.name && packageConfig.version && (packageConfig.description || packageConfig.repository || packageConfig.author || packageConfig.license || packageConfig.scripts);


### PR DESCRIPTION
Fixes problem where peerDependencies of npm packages installed fro a github endpoint would try to install packages resolved to the wrong names