### PR TITLE
Add passing of TLS/SSL configuration to request from config

### DIFF
--- a/github.js
+++ b/github.js
@@ -101,7 +101,7 @@ var GithubLocation = function(options, ui) {
     if (key in options) {
       self.defaultRequestOptions[key] = options[key];
     }
-  }
+  });
 
   this.name = options.name;
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "expand-tilde": "^1.2.0",
     "graceful-fs": "^3.0.6",
-    "merge": "^1.2.0",
     "mkdirp": "~0.5.0",
     "netrc": "^0.1.3",
     "request": "~2.53.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "url": "https://github.com/jspm/github/issues"
   },
   "dependencies": {
+    "expand-tilde": "^1.2.0",
     "graceful-fs": "^3.0.6",
+    "merge": "^1.2.0",
     "mkdirp": "~0.5.0",
     "netrc": "^0.1.3",
     "request": "~2.53.0",


### PR DESCRIPTION
I had a desire to work with a custom CA using a method other than completely turning off SSL verification. The implementation for this option was mentioned in jspm/jspm-cli#980. Since an Enterprise GitHub instance was the only one had a need for currently, that is where I started. I expect in the near future I'll have a need for an NPM registry as well.

I included `expand-title` because my custom certificates are stored with my dotfiles which are all relative to my home directory. If you would rather go to requiring explicit paths, I'd be willing to change.