### PR TITLE
replace tar with tar-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "request": "~2.53.0",
     "rimraf": "~2.3.2",
     "semver": "^5.0.1",
-    "tar": "^2.2.1",
+    "tar-fs": "^1.13.0",
     "which": "^1.0.9"
   },
   "homepage": "https://github.com/jspm/github",


### PR DESCRIPTION
see https://github.com/jspm/npm/pull/141 for comments, this is the same but for github. with my other patch downloading should be even faster now.