### PR TITLE
Insert token in credential object if relevant

### DIFF
--- a/github.js
+++ b/github.js
@@ -65,7 +65,7 @@ function decodeCredentials(str) {
   }
 
   var token;
-  if (isGithubToken(this.auth.password)) {
+  if (this.auth && isGithubToken(this.auth.password)) {
     token = this.auth.password;
   }
 
@@ -89,7 +89,7 @@ function readNetrc(hostname) {
 }
 
 function isGithubToken(token) {
-  return token.match(/[0-9a-f]{40}/);
+  return token && token.match(/[0-9a-f]{40}/);
 }
 
 var GithubLocation = function(options, ui) {

--- a/github.js
+++ b/github.js
@@ -64,9 +64,15 @@ function decodeCredentials(str) {
     password = auth[1];
   }
 
+  var token;
+  if (isGithubToken(this.auth.password)) {
+    token = this.auth.password;
+  }
+
   return {
     username: username,
-    password: password
+    password: password,
+    token: token
   };
 }
 


### PR DESCRIPTION
In order to have the `release.url` request authenticated here https://github.com/jspm/github/blob/cf5e7dd47e00e042a8e14550b5b643a247156af4/github.js#L648
Which would not be the case if you use a `username`+`password` combination.