### PR TITLE
Fix a mistype in fs.mkdir call

### DIFF
--- a/github.js
+++ b/github.js
@@ -585,7 +585,7 @@ GithubLocation.prototype = {
           .on('finish', function() {
             return clearDir(tmpDir)
             .then(function() {
-              return asp(fs.mkdir(tmpDir));
+              return asp(fs.mkdir)(tmpDir);
             })
             .then(function() {
               return new Promise(function(resolve, reject) {


### PR DESCRIPTION
Note: I do not use this package, this was found using a semi-automated ecosystem scan.

I have not tested this change, but looks like an obvious mistype. Placing hopes in CI.

I suggest to add some tests to that codepath, because probably some usecases were broken.

Refs: https://github.com/nodejs/node/pull/18668
