### PR TITLE
Fixed issue with github rate limit check

### DIFF
--- a/github.js
+++ b/github.js
@@ -272,14 +272,16 @@ function configureCredentials(config, ui) {
   });
 }
 
-function checkRateLimit(headers) {
-  if (headers.status.match(/^401/))
+function checkRateLimit(response) {
+  if (response.statusCode === 401)
     throw 'Unauthorized response for GitHub API.\n' +
       'Use %jspm registry config github% to reconfigure the credentials, or update them in your ~/.netrc file.';
-  if (headers.status.match(/^406/))
+  if (response.statusCode === 406)
     throw 'Unauthorized response for GitHub API.\n' +
       'If using an access token ensure it has public_repo access.\n' +
       'Use %jspm registry config github% to configure the credentials, or add them to your ~/.netrc file.';
+
+  var headers = response.headers;
 
   if (headers['x-ratelimit-remaining'] != '0')
     return;
@@ -453,7 +455,7 @@ GithubLocation.prototype = {
       }
     }, this.defaultRequestOptions
     )).then(function(res) {
-      var rateLimitResponse = checkRateLimit.call(this, res.headers);
+      var rateLimitResponse = checkRateLimit.call(this, res);
       if (rateLimitResponse)
         return rateLimitResponse;
 
@@ -659,7 +661,7 @@ GithubLocation.prototype = {
           followRedirect: false,
         }, self.defaultRequestOptions
         )).on('response', function(archiveRes) {
-          var rateLimitResponse = checkRateLimit.call(this, archiveRes.headers);
+          var rateLimitResponse = checkRateLimit.call(this, archiveRes);
           if (rateLimitResponse)
             return rateLimitResponse.then(resolve, reject);
 
@@ -750,7 +752,7 @@ GithubLocation.prototype = {
 
     return asp(request)(reqOptions)
     .then(function(res) {
-      var rateLimitResponse = checkRateLimit.call(this, res.headers);
+      var rateLimitResponse = checkRateLimit.call(this, res);
       if (rateLimitResponse)
         return rateLimitResponse;
       return Promise.resolve()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspm-github",
-  "version": "0.13.20",
+  "version": "0.13.21",
   "description": "jspm GitHub endpoint",
   "main": "github.js",
   "scripts": {


### PR DESCRIPTION
@guybedford Github seems to have changed the headers and the rate limiting functionality stopped working.
The changes below worked for me.  It would be awesome if you could patch the older 0.13.x branch and update the package in npm.  Cheers mate