### PR TITLE
jspm/project#77 send personal access token via request header instead…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jspm-github",
-  "version": "0.13.22",
+  "version": "0.13.23",
   "description": "jspm GitHub endpoint",
   "main": "github.js",
   "scripts": {


### PR DESCRIPTION
… of query param

Changes necessary for this deprecation:
https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/