### PR TITLE
chore: update token validation to support new Github token format

### DIFF
--- a/github.js
+++ b/github.js
@@ -89,7 +89,7 @@ function readNetrc(hostname) {
 }
 
 function isGithubToken(token) {
-  return token && token.match(/[0-9a-f]{40}/);
+  return token && token.match(/[0-9a-zA-Z_]{40,255}/);
 }
 
 var GithubLocation = function(options, ui) {


### PR DESCRIPTION
Github [introduced](https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/) new token formats and is actively encouraging users to switch. Current implementation does not recognize new tokens as tokens thus erroring out on installation when using Github Auth. This adds the support for the new characters in token and also the upcoming changes to token length.